### PR TITLE
fix: module title too long

### DIFF
--- a/training.html
+++ b/training.html
@@ -93,7 +93,7 @@ permalink: /training/
                         <a class="info" href="#" data-tooltip="this feature is coming" data-tooltip-location="left"><i class="fas fa-info-circle"></i></a> <a class="trash" href="#"><i class="fas fa-trash-alt"></i></a>
                         {% if module.module.url %}<a href="{{ module.module.url }}" class="button" target="_blank">Source &nbsp; <i class="fas fa-external-link-alt"></i></a>{% endif %}
                     </div>
-                    <h2>{{ module.module.name }}</h2>
+                    <h2 style="padding-right: 35px;">{{ module.module.name }}</h2>
                     <p class="intro">Learning Objective:</p>
                     {% if module.module.description %}<p class="intro"> {{ module.module.description | markdownify }}</p>{% endif %}
                     <p class="trainer-notes-display"></p>


### PR DESCRIPTION
This fix makes some room for the `info` button to be displayed properly alongside the title of the module

Closes ASKnetCommunity/Training#75