### PR TITLE
176 social preview image and text for overviewstartpage

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,6 +13,15 @@
     <script src="{{ site.baseurl }}/assets/js/popper.min.js"></script>
     <script src="{{ site.baseurl }}/assets/js/bootstrap-5.3.2.min.js"></script>
     <script src="{{ site.baseurl }}/assets/js/shuffle-6.1.0.min.js"></script>
+    <meta property="og:title" content="{{ page.title }}">
+    <meta property="og:site_name" content="{{ site.title }}">
+    {% if page.module.description %}<meta property="og:description" content="{{ page.module.description }}">{% elsif page.description %}<meta property="og:description" content="{{ page.description }}">{% else %}<meta property="og:description" content="{{ site.description }}">{% endif %}
+    <meta property="og:type" content="website">
+    {% if page.module.pic-url %}<meta property="og:image" content="{{ site.url }}{{ base.url }}/assets/img/modules/{{page.module.pic-url }}">{% elsif page.image %}<meta property="og:image" content="{{ site.url }}{{ base.url }}{{ page.image }}">{% else %}<meta property="og:image" content="{{ site.url }}{{ base.url }}/assets/img/screenshot.png">{% endif %}
+    <meta property="og:url" content="{{ site.url }}{{ base.url }}{{ page.url }}" />
+    <meta property="og:locale" content="en_GB" />
+    <meta name="twitter:card" content="summary_large_image">
+    {% if page.module.pic-url %}<meta property="twitter:image" content="{{ site.url }}{{ base.url }}/assets/img/modules/{{page.module.pic-url }}">{% elsif page.image %}<meta property="twitter:image" content="{{ site.url }}{{ base.url }}{{ page.image }}">{% else %}<meta property="twitter:image" content="{{ site.url }}{{ base.url }}/assets/img/screenshot.png">{% endif %}
   </head>
   <body>
     <!-- This section is a template if navigation is required.

--- a/_layouts/trainingsplan.html
+++ b/_layouts/trainingsplan.html
@@ -13,6 +13,15 @@
     <script src="{{ site.baseurl }}/assets/js/sortable-1.15.0.js"></script>
     <script src="{{ site.baseurl }}/assets/js/trainingsplan.js"></script>
     <script src="{{ site.baseurl }}/assets/js/glightbox-3.2.0.min.js"></script>
+    <meta property="og:title" content="{{ page.title }}">
+    <meta property="og:site_name" content="{{ site.title }}">
+    {% if page.module.description %}<meta property="og:description" content="{{ page.module.description }}">{% elsif page.description %}<meta property="og:description" content="{{ page.description }}">{% else %}<meta property="og:description" content="{{ site.description }}">{% endif %}
+    <meta property="og:type" content="website">
+    {% if page.module.pic-url %}<meta property="og:image" content="{{ site.url }}{{ base.url }}/assets/img/modules/{{page.module.pic-url }}">{% elsif page.image %}<meta property="og:image" content="{{ site.url }}{{ base.url }}{{ page.image }}">{% else %}<meta property="og:image" content="{{ site.url }}{{ base.url }}/assets/img/screenshot.png">{% endif %}
+    <meta property="og:url" content="{{ site.url }}{{ base.url }}{{ page.url }}" />
+    <meta property="og:locale" content="en_GB" />
+    <meta name="twitter:card" content="summary_large_image">
+    {% if page.module.pic-url %}<meta property="twitter:image" content="{{ site.url }}{{ base.url }}/assets/img/modules/{{page.module.pic-url }}">{% elsif page.image %}<meta property="twitter:image" content="{{ site.url }}{{ base.url }}{{ page.image }}">{% else %}<meta property="twitter:image" content="{{ site.url }}{{ base.url }}/assets/img/screenshot.png">{% endif %}
     <style>
       /* https://codepen.io/reiinii1/pen/aPGXEa */
       [data-tooltip] {

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 ---
 layout: default
-title: 'Start training plan'
+title: 'Create your own training plan'
+description: 'Browse modules, assemble your training sequence, and easily adjust settings. Print your plan. Ready for a successful training!'
 permalink: /
 ---
 


### PR DESCRIPTION
The title, link, description and image are now shown when sharing on social media platforms.

Descriptions `description:` and images `image:` can now be added to the meta tags of pages. If none are added, the default description in _config.yml and the image in /assets/img/screenshot.png will be used.

For modules, the stored image pic-url and the description are used automatically.